### PR TITLE
Refactor proxy helpers and reuse across scripts

### DIFF
--- a/stage9_parse_catalog_brands.py
+++ b/stage9_parse_catalog_brands.py
@@ -8,6 +8,7 @@ import json
 import random
 from datetime import datetime
 from threading import Lock
+from utils import load_proxies, get_proxy_dict, proxy_lock
 
 # === Константы ===
 URLS = {
@@ -44,46 +45,36 @@ def log(message: str):
             f.write(message + "\n")
 
 # === Загрузка прокси ===
-def load_proxies():
-    if os.path.exists(PROXY_ALIVE_FILE):
-        with open(PROXY_ALIVE_FILE, "r", encoding="utf-8") as f:
-            proxies = [line.strip() for line in f if line.strip()]
-        if proxies:
-            log(f"[INFO] Используем {len(proxies)} живых прокси из {PROXY_ALIVE_FILE}")
-            return proxies
-    if os.path.exists(PROXY_FILE):
-        with open(PROXY_FILE, "r", encoding="utf-8") as f:
-            proxies = [line.strip() for line in f if line.strip()]
-        log(f"[INFO] Используем {len(proxies)} прокси из {PROXY_FILE}")
-        return proxies
-    return []
-
-proxies = load_proxies()
+proxies = load_proxies(PROXY_FILE, PROXY_ALIVE_FILE)
 working_proxies = []
 
 # === Получение HTML через SOCKS5 прокси ===
 def fetch_html(url):
+    """Download a URL using available proxies with retries."""
     global proxies, working_proxies
     for attempt in range(1, RETRIES + 1):
-        local_proxies = proxies.copy()
-        random.shuffle(local_proxies)
+        with proxy_lock:
+            proxy_list = proxies.copy()
+        random.shuffle(proxy_list)
 
-        while local_proxies:
-            proxy = local_proxies.pop()
+        while proxy_list:
+            proxy = proxy_list.pop()
             try:
                 response = requests.get(
                     url, headers=HEADERS,
-                    proxies={"http": f"socks5h://{proxy}", "https": f"socks5h://{proxy}"},
+                    proxies=get_proxy_dict(proxy),
                     timeout=10
                 )
                 response.raise_for_status()
-                if proxy not in working_proxies:
-                    working_proxies.append(proxy)
+                with proxy_lock:
+                    if proxy not in working_proxies:
+                        working_proxies.append(proxy)
                 return response.text
             except Exception as e:
                 log(f"[PROXY ERROR] {proxy} — {e}")
-                if proxy in proxies:
-                    proxies.remove(proxy)
+                with proxy_lock:
+                    if proxy in proxies:
+                        proxies.remove(proxy)
 
         try:
             log(f"[ATTEMPT {attempt}] Пробуем без прокси...")

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,27 @@
+"""Common utilities for Zapo parsers."""
+
+from threading import Lock
+import os
+
+__all__ = ["proxy_lock", "load_proxies", "get_proxy_dict"]
+
+# Shared lock for thread-safe proxy operations
+proxy_lock = Lock()
+
+
+def load_proxies(proxy_file: str, alive_file: str | None = None):
+    """Load a list of proxies, preferring the alive file if provided."""
+    if alive_file and os.path.exists(alive_file):
+        with open(alive_file, "r", encoding="utf-8") as f:
+            proxies = [line.strip() for line in f if line.strip()]
+        if proxies:
+            return proxies
+    if os.path.exists(proxy_file):
+        with open(proxy_file, "r", encoding="utf-8") as f:
+            return [line.strip() for line in f if line.strip()]
+    return []
+
+
+def get_proxy_dict(proxy: str):
+    """Return a requests-compatible proxy dictionary for SOCKS5 proxies."""
+    return {"http": f"socks5h://{proxy}", "https": f"socks5h://{proxy}"}


### PR DESCRIPTION
## Summary
- centralize proxy-related helpers in new `utils.py`
- use shared `load_proxies`, `get_proxy_dict`, and `proxy_lock` across scraping stages
- add thread safety improvements to parts and brand/model scrapers

## Testing
- `python -m py_compile stage6_parse_modifications.py stage7_parse_parts.py stage9_parse_catalog_brands.py stage10_parse_models.py stage11_parse_modification_table.py utils.py`
- `pylint stage6_parse_modifications.py | head`